### PR TITLE
Password encoder incorrect in DaoAuthenticationProviderSecurityBuilder

### DIFF
--- a/src/main/java/org/springframework/security/config/annotation/authentication/DaoAuthenticationProviderSecurityBuilder.java
+++ b/src/main/java/org/springframework/security/config/annotation/authentication/DaoAuthenticationProviderSecurityBuilder.java
@@ -3,7 +3,7 @@ package org.springframework.security.config.annotation.authentication;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.SecurityBuilder;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.authentication.encoding.PasswordEncoder;
 
 public class DaoAuthenticationProviderSecurityBuilder implements SecurityBuilder<DaoAuthenticationProvider> {
     private DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
@@ -15,6 +15,11 @@ public class DaoAuthenticationProviderSecurityBuilder implements SecurityBuilder
     @Override
     public DaoAuthenticationProvider build() throws Exception {
         return provider;
+    }
+
+    public DaoAuthenticationProviderSecurityBuilder passwordEncoder(org.springframework.security.crypto.password.PasswordEncoder passwordEncoder) {
+        provider.setPasswordEncoder(passwordEncoder);
+        return this;
     }
 
     public DaoAuthenticationProviderSecurityBuilder passwordEncoder(PasswordEncoder passwordEncoder) {


### PR DESCRIPTION
org.springframework.security.authentication.dao.DaoAuthenticationProvider accepts org.springframework.security.authentication.encoding.PasswordEncoder or org.springframework.security.crypto.password.PasswordEncoder which it creates a delegate for.

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.
