### PR TITLE
Usage of raw types.

### DIFF
--- a/src/main/java/org/springframework/security/config/annotation/authentication/AuthenticationManagerBuilder.java
+++ b/src/main/java/org/springframework/security/config/annotation/authentication/AuthenticationManagerBuilder.java
@@ -120,10 +120,10 @@ public class AuthenticationManagerBuilder extends AbstractConfiguredSecurityBuil
      * @see org.springframework.security.config.annotation.authentication.AuthenticationRegistry#userDetailsService(org.springframework.security.core.userdetails.UserDetailsService)
      */
     @Override
-    public DaoAuthenticationConfigurator userDetailsService(
+    public DaoAuthenticationConfigurator<UserDetailsService> userDetailsService(
             UserDetailsService userDetailsService) throws Exception {
         this.defaultUserDetailsService = userDetailsService;
-        return apply(new DaoAuthenticationConfigurator(userDetailsService));
+        return apply(new DaoAuthenticationConfigurator<UserDetailsService>(userDetailsService));
     }
 
     /**

--- a/src/main/java/org/springframework/security/config/annotation/authentication/DaoAuthenticationConfigurator.java
+++ b/src/main/java/org/springframework/security/config/annotation/authentication/DaoAuthenticationConfigurator.java
@@ -48,7 +48,7 @@ public class DaoAuthenticationConfigurator<T extends UserDetailsService> extends
      * @param passwordEncoder The {@link PasswordEncoder} to use.
      * @return
      */
-    public DaoAuthenticationConfigurator passwordEncoder(PasswordEncoder passwordEncoder) {
+    public DaoAuthenticationConfigurator<T> passwordEncoder(PasswordEncoder passwordEncoder) {
         provider.setPasswordEncoder(passwordEncoder);
         return this;
     }


### PR DESCRIPTION
Usage of raw types in the DaoAuthenticationConfigurator and AuthenticationManagerBuilder makes build() require a cast to AuthenticationManager.

``` java
    @Bean
    protected AuthenticationManager authenticationManager() throws Exception {
        return (AuthenticationManager) new AuthenticationManagerBuilder().userDetailsService(myUserDetailsService).passwordEncoder(passwordEncoder).and().build();
    }
```
