### PR TITLE
Changed deafult filter name to a constant

### DIFF
--- a/spring-security-javaconfig/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfiguration.java
+++ b/spring-security-javaconfig/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfiguration.java
@@ -55,6 +55,7 @@ import org.springframework.util.ClassUtils;
  * @see WebSecurity
  *
  * @author Rob Winch
+ * @author Keesun Baik
  * @since 3.2
  */
 @Configuration
@@ -65,8 +66,10 @@ public class WebSecurityConfiguration implements ImportAware, BeanClassLoaderAwa
 
     private ClassLoader beanClassLoader;
 
+    public static final String DEFAULT_FILTER_NAME = "springSecurityFilterChain";
+
     @Bean
-    @DependsOn("springSecurityFilterChain")
+    @DependsOn(DEFAULT_FILTER_NAME)
     public SecurityExpressionHandler<FilterInvocation> webSecurityExpressionHandler() {
         return webSecurity.getExpressionHandler();
     }
@@ -76,7 +79,7 @@ public class WebSecurityConfiguration implements ImportAware, BeanClassLoaderAwa
      * @return
      * @throws Exception
      */
-    @Bean(name="springSecurityFilterChain")
+    @Bean(name=DEFAULT_FILTER_NAME)
     public Filter springSecurityFilterChain() throws Exception {
         boolean hasConfigurers = webSecurityConfigurers != null && !webSecurityConfigurers.isEmpty();
         if(!hasConfigurers) {
@@ -91,7 +94,7 @@ public class WebSecurityConfiguration implements ImportAware, BeanClassLoaderAwa
      * @throws Exception
      */
     @Bean
-    @DependsOn("springSecurityFilterChain")
+    @DependsOn(DEFAULT_FILTER_NAME)
     public WebInvocationPrivilegeEvaluator privilegeEvaluator() throws Exception {
         return webSecurity.getPrivilegeEvaluator();
     }


### PR DESCRIPTION
I've just changed ""springSecurityFilterChain" String to a constant named <code>DEFAULT_FILTER_NAME</code>.

When I tried to register a <code>DelegatingFilterProxy</code> for the Spring Security's fileter chain bean, I couldn't remember the target bean name and after I found it I felt it is not easy to type(it is a little bit long to type ti exactly).

I think this will be helpful to those who want to use Spring Security JavaConfig.

now

``` java
@Override
protected Filter[] getServletFilters() {
    ...
    DelegatingFilterProxy securityFilter = new DelegatingFilterProxy();
    securityFilter.setTargetBeanName("springSecurityFilterChain");

    ...
}
```

hope to

``` java
@Override
protected Filter[] getServletFilters() {
    ...
    DelegatingFilterProxy securityFilter = new DelegatingFilterProxy();
    securityFilter.setTargetBeanName(WebSecurityConfiguration.DEFAULT_FILTER_NAME);

    ...
}
```

I'm not sure if the constant is on the right place. You can move it to wherever you want.

Thanks.
