### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 
 buildscript {
     repositories {
-        maven { url 'http://repo.springsource.org/plugins-release' }
+        maven { url 'https://repo.springsource.org/plugins-release' }
     }
     dependencies {
         classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.2'
@@ -45,7 +45,7 @@ configure(subprojects) { p->
     targetCompatibility=1.5
 
     repositories {
-        maven { url "http://repo.springsource.org/libs-snapshot" }
+        maven { url "https://repo.springsource.org/libs-snapshot" }
         mavenCentral()
     }
 
@@ -137,7 +137,7 @@ configure(rootProject) {
         baseName = "spring-security-javaconfig"
         classifier = "docs"
         description = "Builds -${classifier} archive containing api and reference " +
-            "for deployment at http://static.springframework.org/spring-security-javaconfig/docs."
+            "for deployment at https://docs.spring.io/spring-security-javaconfig/docs."
 
         from (project(":spring-security-javaconfig").javadoc) {
             into "api-reference"

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -16,7 +16,7 @@ def customizePom(pom, gradleProject) {
             licenses {
                 license {
                     name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     distribution 'repo'
                 }
             }

--- a/samples/oauth2-sparklr/pom.xml
+++ b/samples/oauth2-sparklr/pom.xml
@@ -86,16 +86,16 @@
 		<repository>
 			<id>spring-milestone</id>
 			<name>Spring Framework Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 		</repository>
 		<repository>
 			<id>spring-release</id>
 			<name>Spring Framework Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</repository>
 		<repository>
 			<id>java.net</id>
-			<url>http://download.java.net/maven/2</url>
+			<url>https://download.java.net/maven/2</url>
 		</repository>
 	</repositories>
 

--- a/samples/oauth2-tonr/pom.xml
+++ b/samples/oauth2-tonr/pom.xml
@@ -86,12 +86,12 @@
 		<repository>
 			<id>spring-milestone</id>
 			<name>Spring Framework Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 		</repository>
 		<repository>
 			<id>spring-release</id>
 			<name>Spring Framework Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://static.springframework.org/spring-security-javaconfig/docs (301) migrated to:  
  https://docs.spring.io/spring-security-javaconfig/docs ([https](https://static.springframework.org/spring-security-javaconfig/docs) result 404).
* http://download.java.net/maven/2 (301) migrated to:  
  https://download.java.net/maven/2 ([https](https://download.java.net/maven/2) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://repo.springsource.org/libs-snapshot migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).
* http://repo.springsource.org/plugins-release migrated to:  
  https://repo.springsource.org/plugins-release ([https](https://repo.springsource.org/plugins-release) result 301).
* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://maven.springframework.org/release migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance